### PR TITLE
Check domain belongs to provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.0 (14 January 2019)
+
+* [*] The /settings call returns a response that indicates the domain does not belong to the DNS provider.
+
 # 1.1.3 (27 December 2018)
 
 * [*] Updated templates

--- a/src/htdocs/public/index.php
+++ b/src/htdocs/public/index.php
@@ -1,0 +1,33 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+require_once 'sdk.php';
+pm_Context::init('domain-connect');
+
+if (!pm_Config::get('dnsProvider')) {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 403 The DNS provider is disabled by server configuration', true, 400);
+    exit;
+}
+
+if (!preg_match('|/v2/(.*)/settings|', $_SERVER['REQUEST_URI'], $matches)) {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request', true, 400);
+    exit;
+}
+$domain = $matches[1];
+
+try {
+    $pmDomain = pm_Domain::getByName($domain);
+} catch (pm_Exception $e) {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 404 The domain does not belong to the DNS provider', true, 404);
+    exit;
+}
+
+$data = array_filter([
+    'providerId' => pm_Config::get('providerId'),
+    'providerName' => pm_Config::get('providerName'),
+    'providerDisplayName' => pm_Config::get('providerDisplayName', empty($_GET['providerDisplayName']) ? null : $_GET['providerDisplayName']),
+    'urlSyncUX' => 'https://' . $_SERVER['HTTP_HOST'] . '/modules/domain-connect/index.php/',
+    'urlAPI' => 'https://' . $_SERVER['HTTP_HOST'] . '/modules/domain-connect/index.php/',
+    'width' => 750,
+    'height' => 750,
+]);
+echo json_encode($data);

--- a/src/meta.xml
+++ b/src/meta.xml
@@ -6,7 +6,7 @@
   <description>The Plesk Domain Connect Extension solves this issue by automatically configuring DNS for your website.</description>
   <category>dns</category>
   <url>https://plesk.com</url>
-  <version>1.1.3</version>
+  <version>1.2.0</version>
   <release>{{RELEASE}}</release>
   <vendor>Plesk</vendor>
   <plesk_min_version>17.0</plesk_min_version>


### PR DESCRIPTION
The /settings call returns a response that indicates the domain does not belong to the DNS provider